### PR TITLE
Add new evaluation link for AutoCLRS specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ See the [Intent Formalization blog](https://risemsr.github.io/blog/2026-03-05-sh
 - [TiCoder: Test-driven User-Intent Formalization (TSE'24 article)](https://github.com/microsoft/ticoder)
 - [Can Large Language Models Transform Natural Language Intent into Formal Method Postconditions? (FSE'24 article)](nl2postcondition-fse2024)
 - [Evaluating LLM-driven User-Intent Formalization for Verification-Aware Languages (FMCAD'24 article)](eval-formal-specs-fmcad2024)
+- **New**: [Evaluating specifications for AutoCLRS textbook algorithms in F*](eval-autoclrs-specs)
 
 ## Contributing
 


### PR DESCRIPTION
Added a new link for evaluating specifications related to AutoCLRS textbook algorithms in F*.